### PR TITLE
fix: fix i18next options

### DIFF
--- a/app/modules/i18n/i18n.server.ts
+++ b/app/modules/i18n/i18n.server.ts
@@ -12,8 +12,8 @@ export const localeCookie = createCookie('lng', {
 
 export default new RemixI18Next({
   detection: {
-    supportedLanguages: i18n.supportedLangs,
-    fallbackLanguage: i18n.fallbackLang,
+    supportedLanguages: i18n.supportedLngs,
+    fallbackLanguage: i18n.fallbackLng,
     cookie: localeCookie,
   },
   // Configuration for i18next used when

--- a/app/modules/i18n/i18n.ts
+++ b/app/modules/i18n/i18n.ts
@@ -4,17 +4,17 @@ import es from '#app/modules/i18n/locales/es'
 const languages = ['es', 'en'] as const
 
 // List of languages your application supports.
-export const supportedLangs = [...languages]
+export const supportedLngs = [...languages]
 
-// Fallback language will be used if the user language is not in the supportedLangs.
-export const fallbackLang = 'en'
+// Fallback language will be used if the user language is not in the supportedLngs.
+export const fallbackLng = 'en'
 
 // Default namespace of i18next is "translation", but you can customize it here.
 export const defaultNS = 'translation'
 
 // Translation files we created, with 'translation' as the default namespace.
 // We'll use these to include the translations in the bundle, instead of loading them on-demand.
-export type Languages = (typeof supportedLangs)[number]
+export type Languages = (typeof supportedLngs)[number]
 
 export type Resource = {
   translation: typeof en


### PR DESCRIPTION
Hi :wave:,
Thank you for this amazing stack, it's a real pleasure to read your code.
This PR fix 2 `i18next` options which TypeScript forgot to mention.
![i18next](https://github.com/user-attachments/assets/208a40aa-c944-4207-a1e6-e49e2817d48a)
[documentation](https://www.i18next.com/overview/configuration-options)

Have a good evening !