### PR TITLE
fix prisma seed create only one instance of prisma client

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,10 +1,10 @@
 import type { Interval } from '#app/modules/stripe/plans'
 import { PrismaClient } from '@prisma/client'
-import { prisma } from '#app/utils/db.server'
 import { stripe } from '#app/modules/stripe/stripe.server'
 import { PRICING_PLANS } from '#app/modules/stripe/plans'
 
-const client = new PrismaClient()
+const prisma = new PrismaClient()
+prisma.$connect()
 
 async function seed() {
   /**
@@ -157,10 +157,11 @@ async function seed() {
 }
 
 seed()
-  .catch((err: unknown) => {
+  .catch(async (err) => {
     console.error(err)
+    await prisma.$disconnect()
     process.exit(1)
   })
-  .finally(async () => {
-    await client.$disconnect()
+  .then(async () => {
+    await prisma.$disconnect()
   })

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,10 +1,7 @@
 import type { Interval } from '#app/modules/stripe/plans'
-import { PrismaClient } from '@prisma/client'
 import { stripe } from '#app/modules/stripe/stripe.server'
 import { PRICING_PLANS } from '#app/modules/stripe/plans'
-
-const prisma = new PrismaClient()
-prisma.$connect()
+import { prisma } from '#app/utils/db.server.ts'
 
 async function seed() {
   /**


### PR DESCRIPTION
good evening again :wave: ,
this time a mini correction on the prisma seed script, in fact 2 prisma instances are created and only one is used. this does not change much but the code is clearer.
